### PR TITLE
Fix infinite scroll selection

### DIFF
--- a/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.html
+++ b/src/app/examples/08-infinite-scroll-example/infinite-scroll-example.component.html
@@ -5,7 +5,7 @@
 </p>
 
 <mat-form-field>
-  <mat-select  msInfiniteScroll (infiniteScroll)="getNextBatch()"
+  <mat-select #matSelectInfiniteScroll msInfiniteScroll (infiniteScroll)="getNextBatch()"
     [formControl]="ctrl"
     placeholder="Select Something"
     (valueChange)="onChange($event)">


### PR DESCRIPTION
This PR fixes an [issue ](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/243) that was mentioned in a [comment ](https://github.com/bithost-gmbh/ngx-mat-select-search/issues/243#issuecomment-666098889) a few days ago.

With the infinite scroll example it is not possible to select an item beyond option nine. This is caused by calling `onSearchChange` whenever the select closes.